### PR TITLE
Accept a url to a service instead of breaking the url into base_url, fol...

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ like GeoJSON.
 
 ```python
 >>> import arcgis
->>> arc = arcgis.ArcGIS("http://www.pathtomapserver:6080/", "FOLDER_OF_PROJECTS", "MAP_DATA_I_WANT")
->>> layer_id = 1
->>> arc.get(layer_id)
+>>> source = "http://services.arcgis.com/P3ePLMYs2RVChkJx/ArcGIS/rest/services/USA_Congressional_Districts/FeatureServer"
+>>> arc = arcgis.ArcGIS(source)
+>>> layer_id = 0
+>>> shapes = arc.get(layer_id, "STATE_ABBR='IN'")
 ```
 
 This assumes you've inspected your ArcGIS services endpoint to know what to look for.
@@ -41,15 +42,15 @@ You can also use the included arcgis-get utility, like so:
 
 *Note: this query will take a long time, so maybe try one of the other examples below?*
 ```bash
-arcgis-get http://tigerweb.geo.census.gov/ Basemaps CommunityTIGER 9 > ~/Desktop/railroads.geojson
+arcgis-get http://tigerweb.geo.census.gov/arcgis/rest/services/Basemaps/CommunityTIGER/MapServer 9 > ~/Desktop/railroads.geojson
 ```
 
-This will download a Railroads layer from the US Census' TIGER dataset. 
+This will download a Railroads layer from the US Census' TIGER dataset.
 
 The size of that file brings up a good point: you should run `--count_only` before downloading an entire dataset, so you can see what you're in store for. 
 
 ```bash
-$ arcgis-get http://tigerweb.geo.census.gov/ Basemaps CommunityTIGER 9 --count_only
+$ arcgis-get http://tigerweb.geo.census.gov/arcgis/rest/services/Basemaps/CommunityTIGER/MapServer 9 --count_only
 182149
 ```
 Since we go in batches of 1,000, you're in for over 180 queries to the API.
@@ -65,7 +66,7 @@ npm install -g geojsonio-cli
 Then, we could re-do the previous query:
 
 ```bash
-arcgis-get http://tigerweb.geo.census.gov/ Basemaps CommunityTIGER 9 | geojsonio
+arcgis-get http://tigerweb.geo.census.gov/arcgis/rest/services/Basemaps/CommunityTIGER/MapServer 9 | geojsonio
 ```
 
 And get some glorious mapped output: 
@@ -75,7 +76,7 @@ You can also do WHERE filtering from the command line. For example, if you want 
 and display it on geojson.io, you could do:
 
 ```bash
-arcgis-get --where="NAME = 'Florida'" http://tigerweb.geo.census.gov/ Basemaps CommunityTIGER 28 | geojsonio
+arcgis-get --where="NAME = 'Florida'" http://tigerweb.geo.census.gov/arcgis/rest/services/Basemaps/CommunityTIGER/MapServer 28 | geojsonio
 ```
 ![florida](https://cloud.githubusercontent.com/assets/20067/5001808/ee233ff6-69c7-11e4-9c3e-245aba847bb5.png)
 

--- a/arcgis/arcgis.py
+++ b/arcgis/arcgis.py
@@ -10,19 +10,18 @@ class ArcGIS:
     Usage:
 
     >>> import arcgis
-    >>> arc = arcgis.ArcGIS("http://www.pathtomapserver:6080/", "FOLDER_OF_PROJECTS", "MAP_DATA_I_WANT")
-    >>> layer_id = 1
-    >>> arc.get(layer_id)
+    >>> source = "http://services.arcgis.com/P3ePLMYs2RVChkJx/ArcGIS/rest/services/USA_Congressional_Districts/FeatureServer"
+    >>> arc = arcgis.ArcGIS(source)
+    >>> layer_id = 0
+    >>> shapes = arc.get(layer_id, "STATE_ABBR='IN'")
 
     This assumes you've inspected your ArcGIS services endpoint to know what to look for.
     ArcGIS DOES publish json files enumerating the endpoints you can query, so autodiscovery
     could be possible further down the line.
 
     """
-    def __init__(self, base_url, folder, map_name):
-        self.base_url=base_url
-        self.folder=folder
-        self.map=map_name
+    def __init__(self, url):
+        self.url=url
         self._layer_descriptor_cache = {}
         self._geom_parsers = {
             'esriGeometryPoint': self._parse_esri_point,
@@ -32,13 +31,7 @@ class ArcGIS:
         }
 
     def _build_request(self, layer):
-        return urljoin(self.base_url,
-            "arcgis/rest/services", 
-            self.folder,
-            self.map,
-            "MapServer",
-            layer
-            )
+        return urljoin(self.url, layer)
 
     def _build_query_request(self, layer):
         return urljoin(self._build_request(layer), "query")

--- a/bin/arcgis-get
+++ b/bin/arcgis-get
@@ -7,13 +7,9 @@ import json
 if __name__ == "__main__":
 	parser = argparse.ArgumentParser(description="Output an ArcGIS web layer as GeoJSON")
 	parser.add_argument('url', type=str,
-                   help='The base address of the ArcGIS web instance')
-	parser.add_argument('folder', type=str,
-                   help='The folder containing the map')
-	parser.add_argument('map', type=str,
-                   help='The map name')
+                   help='The full url to an ArcGIS web service')
 	parser.add_argument('layer', type=int,
-                   help='The layer id within the map')
+                   help='The layer id within the service')
 	parser.add_argument('--where', type=str, default="1 = 1",
 					help="A SQL-like WHERE clause to filter the data.")
 	parser.add_argument('--count_only', action='store_true',
@@ -21,6 +17,6 @@ if __name__ == "__main__":
 
 	args = parser.parse_args()
 
-	arc = arcgis.ArcGIS(args.url, args.folder, args.map)
+	arc = arcgis.ArcGIS(args.url)
 	
 	print json.dumps(arc.get(args.layer, where=args.where, count_only=args.count_only))


### PR DESCRIPTION
...der and map_data. This gets rid of also hard-coding arcgis/rest/services and MapServer in ArcGIS._build_request which in turn allows this tool to work with feature services as well as map services.
