### PR TITLE
Invalid Control Character Error Fix

### DIFF
--- a/arcgis/arcgis.py
+++ b/arcgis/arcgis.py
@@ -87,7 +87,7 @@ class ArcGIS:
                 'orderByFields': "OBJECTID",
                 'returnCountOnly': count_only
             })
-        return response.json()
+        return response.json(strict=False)
 
     def get_descriptor_for_layer(self, layer):
         """


### PR DESCRIPTION
Passing the 'strict=False' argument in 'response.json()' prevents the invalid control character error which occurs if there is a control character present in the returned JSON.