### PR TITLE
Return null value as geometry when no geometry exists for feature

### DIFF
--- a/arcgis/arcgis.py
+++ b/arcgis/arcgis.py
@@ -80,7 +80,7 @@ class ArcGIS:
         return {
             "type": "Feature",
             "properties": obj.get('attributes'),
-            "geometry": geom_parser(obj.get('geometry'))
+            "geometry": geom_parser(obj.get('geometry')) if obj.get('geometry') else None
         }
 
     def get_json(self, layer, where="1 = 1", fields=[], count_only=False, srid='4326'):


### PR DESCRIPTION
It seems odd, but features returned by an Arcgis json service might be without geometry. I. e. incidents they need to report, but that have yet to be geocoded etc. In the current implementation the script fails on these missing geometries. This PR is a quick fix to that. (And yes, geojson allows for null values in geometry: http://geojson.org/geojson-spec.html#feature-objects)