### PR TITLE
update package to work with python 3.5.2

### DIFF
--- a/arcgis/__init__.py
+++ b/arcgis/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['ArcGIS']
-from arcgis.arcgis import ArcGIS
+from .arcgis import ArcGIS

--- a/arcgis/__init__.py
+++ b/arcgis/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['ArcGIS']
-from arcgis import ArcGIS
+from arcgis.arcgis import ArcGIS

--- a/arcgis/arcgis.py
+++ b/arcgis/arcgis.py
@@ -108,7 +108,7 @@ class ArcGIS:
         Returns the standard JSON descriptor for the layer. There is a lot of
         usefule information in there.
         """
-        if not self._layer_descriptor_cache.has_key(layer):
+        if not layer in self._layer_descriptor_cache:
             params = {'f': 'pjson'}
             if self.token:
                 params['token'] = self.token

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ coverage==3.7.1
 coveralls==0.4.4
 docopt==0.6.2
 requests==2.4.3
-wsgiref==0.1.2
+wsgiref==0.1.2 ; python_version < '3.0'


### PR DESCRIPTION
3 changes made to make package compatible with python 3

Tests pass on python 2.7 & 3.5.2

Tests on 3.5.2 give "Resource Warning" for an unclosed socket but this is expected as the socket is kept open for all the tests.